### PR TITLE
Fix arguments type for BlockingChannel.queue_declare

### DIFF
--- a/pika-stubs/adapters/blocking_connection.pyi
+++ b/pika-stubs/adapters/blocking_connection.pyi
@@ -229,7 +229,7 @@ class BlockingChannel:
         durable: bool = ...,
         exclusive: bool = ...,
         auto_delete: bool = ...,
-        arguments: Optional[spec.Queue.DeclareOk] = ...,
+        arguments: Optional[Mapping[str, Any]] = ...,
     ) -> frame.Method[spec.Queue.DeclareOk]: ...
 
     def queue_delete(


### PR DESCRIPTION
Fixes hahow/pika-stubs/issues/2.

Signed-off-by: Anders Kaseorg <andersk@mit.edu>

---

From hahow/pika-stubs/pull/6