### PR TITLE
Allow basic_publish with either str or bytes

### DIFF
--- a/pika-stubs/adapters/blocking_connection.pyi
+++ b/pika-stubs/adapters/blocking_connection.pyi
@@ -185,7 +185,7 @@ class BlockingChannel:
         self,
         exchange: str,
         routing_key: str,
-        body: bytes,
+        body: bytes | str,
         properties: Optional[spec.BasicProperties] = ...,
         mandatory: bool = ...,
     ) -> None: ...

--- a/pika-stubs/adapters/twisted_connection.pyi
+++ b/pika-stubs/adapters/twisted_connection.pyi
@@ -117,7 +117,7 @@ class TwistedChannel:
         self,
         exchange: str,
         routing_key: str,
-        body: bytes,
+        body: bytes | str,
         properties: Optional[spec.BasicProperties] = ...,
         mandatory: bool = ...,
     ) -> Deferred[None]: ...

--- a/pika-stubs/channel.pyi
+++ b/pika-stubs/channel.pyi
@@ -111,7 +111,7 @@ class Channel:
         self,
         exchange: str,
         routing_key: str,
-        body: bytes,
+        body: bytes | str,
         properties: Optional[spec.BasicProperties] = ...,
         mandatory: bool = ...,
     ) -> None: ...


### PR DESCRIPTION
`channel.basic_publish()` will automatically decode `body` as `utf-8` if it is a `str`:

https://github.com/pika/pika/blob/12dcdf15d0932c388790e0fa990810bfd21b1a32/pika/channel.py#L405-L430

```python
    def basic_publish(self,
                      exchange,
                      routing_key,
                      body,
                      properties=None,
                      mandatory=False):
        """Publish to the channel with the given exchange, routing key and body.
        For more information on basic_publish and what the parameters do, see:

        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish

        :param str exchange: The exchange to publish to
        :param str routing_key: The routing key to bind on
        :param bytes body: The message body
        :param pika.spec.BasicProperties properties: Basic.properties
        :param bool mandatory: The mandatory flag

        """
        self._raise_if_not_open()
        if isinstance(body, unicode_type):
            body = body.encode('utf-8')
        properties = properties or spec.BasicProperties()
        self._send_method(
            spec.Basic.Publish(exchange=exchange,
                               routing_key=routing_key,
                               mandatory=mandatory), (properties, body))
```

fixes #6
