### PR TITLE
Blocking Connection: allow sequence of parameters

### DIFF
--- a/pika-stubs/adapters/blocking_connection.pyi
+++ b/pika-stubs/adapters/blocking_connection.pyi
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import types
-from typing import Any, Callable, Iterator, List, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Iterator, List, Mapping, Optional, Tuple, Type, Union, Sequence
 
 from .. import channel, connection, frame, spec
 
@@ -10,7 +10,7 @@ class BlockingConnection:
 
     def __init__(
         self,
-        parameters: Optional[connection.Parameters] = ...,
+        parameters: connection.Parameters | Sequence[connection.Parameters] | None = ...,
         _impl_class: Optional[Any] = ...,
     ) -> None: ...
 


### PR DESCRIPTION
pika's blocking connection adapter allows for a sequence of parameters, not just a single one 

https://github.com/pika/pika/blob/12dcdf15d0932c388790e0fa990810bfd21b1a32/pika/adapters/blocking_connection.py#L322-L329
```python
class BlockingConnection(object):
    ...
    def __init__(self, parameters=None, _impl_class=None):
        """Create a new instance of the Connection object.

        :param None | pika.connection.Parameters | sequence parameters:
            Connection parameters instance or non-empty sequence of them. If
            None, a `pika.connection.Parameters` instance will be created with
            default settings. See `pika.AMQPConnectionWorkflow` for more
            details about multiple parameter configurations and retries.
```

https://github.com/pika/pika/blob/12dcdf15d0932c388790e0fa990810bfd21b1a32/pika/adapters/blocking_connection.py#L403-L420
```python
    def _create_connection(self, configs, impl_class):
        """Run connection workflow, blocking until it completes.

        :param None | pika.connection.Parameters | sequence configs: Connection
            parameters instance or non-empty sequence of them.
        :param None | SelectConnection impl_class: for tests/debugging only;
            implementation class;

        :rtype: impl_class

        :raises: exception on failure
        """


        if configs is None:
            configs = (pika.connection.Parameters(),)


        if isinstance(configs, pika.connection.Parameters):
            configs = (configs,)
```

Closes #5 